### PR TITLE
Addition of depositCaching parameter for gateways

### DIFF
--- a/app/components/Modal/DepositModal.jsx
+++ b/app/components/Modal/DepositModal.jsx
@@ -184,7 +184,11 @@ class DepositModalContent extends DecimalChecker {
         this._getDepositConfirmation(backingAsset);
 
         let depositAddress;
-        if (selectedGateway && selectedAsset) {
+        if (
+            selectedGateway &&
+            selectedAsset &&
+            gatewayStatus[selectedGateway].depositCaching
+        ) {
             depositAddress = this.deposit_address_cache.getCachedInputAddress(
                 selectedGateway.toLowerCase(),
                 account,

--- a/app/lib/common/gateways.js
+++ b/app/lib/common/gateways.js
@@ -92,6 +92,7 @@ export const availableGateways = {
         name: "ioxbank",
         baseAPI: ioxbankAPIs,
         isEnabled: _isEnabled("IOB"),
+        depositCaching: true,
         isSimple: true,
         selected: false,
         simpleAssetGateway: true,
@@ -178,6 +179,7 @@ export const availableGateways = {
         name: "GDEX",
         baseAPI: gdex2APIs,
         isEnabled: _isEnabled("GDEX"),
+        depositCaching: true,
         options: {
             enabled: false,
             selected: false
@@ -189,6 +191,7 @@ export const availableGateways = {
         name: "XBTS Native Chains",
         baseAPI: xbtsxAPIs,
         isEnabled: _isEnabled("XBTSX"),
+        depositCaching: true,
         isSimple: true,
         selected: false,
         addressValidatorMethod: "POST",


### PR DESCRIPTION
This PR adds functionality to choose whether or not a gateway allows for cached deposit addresses/memos. While being a small change (4 lines), this adds major modular improvement by allowing for gateways with unique deposit requirements. Changes have been added to each active gateway setting this parameter to 'true' to continue with prior UI functionality.

<h2>General</h2>
Closes #[Insert issue number]

[Insert description of what you did, any description how to test or check your changes are welcome]

<h2>General</h2>
Please make sure the following is done:

- Pull request is onto develop
- If you haven't already, have a look at
  - https://github.com/bitshares/bitshares-ui/blob/develop/CODE_OF_CONDUCT.md
  - https://github.com/bitshares/bitshares-ui/blob/develop/CONTRIBUTING.md

<h2>Code Preparation</h2>

_Please review all your changes one last time before committing_

- [ ] Check for unused code
- [ ] No unrelated changes are included
- [ ] None of the changed files are reformatting only
- [ ] Code is self explanatory or documented
- [ ] All written text is properly translated (english language)

<h2>Testing</h2>

_The branch has been tested on the following browsers (desktop and mobile view)_

- [ ] Chrome 
- [ ] Opera
- [ ] Firefox
- [ ] Safari

<h2>User interface changes</h2>

_Delete this section if there weren't any UI changes. Please make sure you tested your changes in all themes_

- [ ] Dark
- [ ] Light
- [ ] Midnight

_Please provide screenshots/licecap of your changes below_